### PR TITLE
Implement light theme palette

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Music Affiliate Dashboard</title>
   </head>
-  <body class="bg-dark text-white font-suisse">
+  <body class="bg-light text-black font-suisse">
     <div id="root"></div>
   </body>
 </html>

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -6,22 +6,22 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 
 export default function Dashboard() {
   return (
-    <div className="min-h-screen bg-[#0C0C0F] text-white font-suisse p-6 space-y-6">
+    <div className="min-h-screen bg-light text-black font-suisse p-6 space-y-6">
       <h1 className="text-4xl font-bold drop-shadow-[0_0_5px_rgba(255,0,80,0.5)]">
         GustavoLab Dashboard
       </h1>
 
       <Tabs defaultValue="dashboard">
-        <TabsList className="bg-[#1A1A1F] rounded-md p-1 shadow-neon">
-          <TabsTrigger value="dashboard" className="text-white hover:text-accent">Dashboard</TabsTrigger>
-          <TabsTrigger value="channels" className="text-white hover:text-accent">My Channels</TabsTrigger>
-          <TabsTrigger value="videos" className="text-white hover:text-accent">Videos</TabsTrigger>
-          <TabsTrigger value="reports" className="text-white hover:text-accent">Reports</TabsTrigger>
-          <TabsTrigger value="payments" className="text-white hover:text-accent">Payments</TabsTrigger>
+        <TabsList className="bg-surface rounded-md p-1 shadow-neon">
+          <TabsTrigger value="dashboard" className="text-black hover:text-accent">Dashboard</TabsTrigger>
+          <TabsTrigger value="channels" className="text-black hover:text-accent">My Channels</TabsTrigger>
+          <TabsTrigger value="videos" className="text-black hover:text-accent">Videos</TabsTrigger>
+          <TabsTrigger value="reports" className="text-black hover:text-accent">Reports</TabsTrigger>
+          <TabsTrigger value="payments" className="text-black hover:text-accent">Payments</TabsTrigger>
         </TabsList>
 
         <TabsContent value="dashboard">
-          <Card className="bg-[#1A1A1F] shadow-neon">
+          <Card className="bg-surface shadow-neon">
             <CardContent className="p-6">
               <h2 className="text-2xl font-semibold mb-4">Overview</h2>
               <p className="text-lg mb-2">Total Earnings: <span className="text-[#FF0040]">$2,450.00</span></p>
@@ -32,7 +32,7 @@ export default function Dashboard() {
         </TabsContent>
 
         <TabsContent value="channels">
-          <Card className="bg-[#1A1A1F] shadow-neon">
+          <Card className="bg-surface shadow-neon">
             <CardContent className="p-6">
               <h2 className="text-2xl font-semibold mb-4">YouTube Channels</h2>
               <Button className="bg-[#FF0040] hover:bg-[#e60036] text-white">Link New Channel</Button>
@@ -41,11 +41,11 @@ export default function Dashboard() {
         </TabsContent>
 
         <TabsContent value="videos">
-          <Card className="bg-[#1A1A1F] shadow-neon">
+          <Card className="bg-surface shadow-neon">
             <CardContent className="p-6 overflow-x-auto">
               <h2 className="text-2xl font-semibold mb-4">Uploaded Videos</h2>
               <table className="min-w-full text-sm">
-                <thead className="text-left text-gray-400">
+                <thead className="text-left text-gray-600">
                   <tr>
                     <th className="p-2">Date</th>
                     <th className="p-2">Campaign</th>
@@ -56,8 +56,8 @@ export default function Dashboard() {
                     <th className="p-2">Status</th>
                   </tr>
                 </thead>
-                <tbody className="text-white">
-                  <tr className="border-t border-gray-700">
+                <tbody className="text-black">
+                  <tr className="border-t border-gray-300">
                     <td className="p-2">Jun 23, 2025</td>
                     <td className="p-2">ReBet</td>
                     <td className="p-2 text-blue-400 underline">Instagram</td>
@@ -73,7 +73,7 @@ export default function Dashboard() {
         </TabsContent>
 
         <TabsContent value="reports">
-          <Card className="bg-[#1A1A1F] shadow-neon">
+          <Card className="bg-surface shadow-neon">
             <CardContent className="p-6">
               <h2 className="text-2xl font-semibold mb-4">Reports</h2>
               <Button className="bg-[#FF0040] hover:bg-[#e60036] text-white">Download CSV</Button>
@@ -82,7 +82,7 @@ export default function Dashboard() {
         </TabsContent>
 
         <TabsContent value="payments">
-          <Card className="bg-[#1A1A1F] shadow-neon">
+          <Card className="bg-surface shadow-neon">
             <CardContent className="p-6 space-y-6">
               <div className="flex items-center justify-between">
                 <div>
@@ -90,14 +90,14 @@ export default function Dashboard() {
                   <p className="text-2xl text-[#FF0040] font-bold">$4.92</p>
                 </div>
                 <div className="space-x-2">
-                  <Button className="bg-[#333] text-white">Edit Payout Method</Button>
+                  <Button className="bg-gray-300 text-black">Edit Payout Method</Button>
                   <Button className="bg-[#FF0040] text-white">Payout</Button>
                 </div>
               </div>
               <div>
                 <h3 className="text-lg font-semibold mb-2">Payout History & Status</h3>
-                <table className="min-w-full text-sm">
-                  <thead className="text-left text-gray-400">
+              <table className="min-w-full text-sm">
+                <thead className="text-left text-gray-600">
                     <tr>
                       <th className="p-2">Date</th>
                       <th className="p-2">Method</th>
@@ -105,8 +105,8 @@ export default function Dashboard() {
                       <th className="p-2">Status</th>
                     </tr>
                   </thead>
-                  <tbody className="text-white">
-                    <tr className="border-t border-gray-700">
+                  <tbody className="text-black">
+                    <tr className="border-t border-gray-300">
                       <td className="p-2">Jun 30, 2025</td>
                       <td className="p-2">Wire Transfer</td>
                       <td className="p-2 text-red-400">-$607.15</td>

--- a/src/index.css
+++ b/src/index.css
@@ -10,5 +10,5 @@
 }
 
 body {
-  @apply bg-dark text-white font-suisse;
+  @apply bg-light text-black font-suisse;
 }

--- a/src/ui/card.js
+++ b/src/ui/card.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 export function Card({ children, className }) {
-  return <div className={`rounded-xl border border-gray-800 bg-[#1A1A1F] ${className}`}>{children}</div>;
+  return <div className={`rounded-xl border border-gray-300 bg-surface ${className}`}>{children}</div>;
 }
 
 export function CardContent({ children, className }) {

--- a/src/ui/tabs.js
+++ b/src/ui/tabs.js
@@ -32,7 +32,7 @@ export function TabsTrigger({ children, value, isActive, onClick, className }) {
   return (
     <button
       onClick={onClick}
-      className={`px-4 py-2 rounded ${isActive ? 'bg-[#FF0040] text-white' : 'bg-[#2a2a2e] text-gray-300'} ${className}`}
+      className={`px-4 py-2 rounded ${isActive ? 'bg-[#FF0040] text-white' : 'bg-surface text-gray-700'} ${className}`}
     >
       {children}
     </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,8 @@ module.exports = {
       },
       colors: {
         dark: '#0C0C0F',
+        light: '#ffffff',
+        surface: '#f3f4f6',
         accent: '#FF0040',
       },
       boxShadow: {


### PR DESCRIPTION
## Summary
- add light and surface colors to Tailwind config
- use `bg-light` with dark text in base CSS and HTML
- adapt dashboard and UI components for light palette

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863e987565483229f8e15d36ce3ae8a