### PR TITLE
Ensure sample data loads outside Telegram

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,30 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Dashboard from './components/Dashboard';
 
 function App() {
-  let telegramId = 'dev-mode-id';
-  try {
-    if (window.Telegram) {
-      telegramId = window.Telegram.WebApp.initDataUnsafe?.user?.id || 'dev-mode-id';
+  const [telegramId, setTelegramId] = useState('dev-mode-id');
+
+  useEffect(() => {
+    let id = 'dev-mode-id';
+    try {
+      if (window.Telegram) {
+        id = window.Telegram.WebApp.initDataUnsafe?.user?.id || 'dev-mode-id';
+      }
+    } catch (err) {
+      console.error('Failed to read telegramId', err);
     }
-  } catch (err) {
-    console.error('Failed to read telegramId', err);
-  }
+
+    setTelegramId(id);
+
+    fetch('/api/user-auth', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'ngrok-skip-browser-warning': 'true'
+      },
+      body: JSON.stringify({ telegramId: id })
+    }).catch(err => console.error('user-auth failed', err));
+  }, []);
 
   console.log('Current telegramId:', telegramId);
 


### PR DESCRIPTION
## Summary
- automatically POST to `/api/user-auth` on startup so the sample data is available without Telegram

## Testing
- `npm test` *(fails: no tests present)*

------
https://chatgpt.com/codex/tasks/task_e_6864f80396f08322a02c198a19fd4063