### PR TITLE
Refactor user ID handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Music Affiliate Dashboard</title>
-    <script src="https://telegram.org/js/telegram-web-app.js"></script>
   </head>
   <body class="bg-light text-black font-suisse">
     <div id="root"></div>

--- a/src/App.js
+++ b/src/App.js
@@ -2,19 +2,18 @@ import React, { useEffect, useState } from 'react';
 import Dashboard from './components/Dashboard';
 
 function App() {
-  const [telegramId, setTelegramId] = useState('dev-mode-id');
+  const DEFAULT_ID = 'dev-mode-id';
+  const [userId, setUserId] = useState(() => {
+    return localStorage.getItem('userId') || DEFAULT_ID;
+  });
 
   useEffect(() => {
-    let id = 'dev-mode-id';
-    try {
-      if (window.Telegram) {
-        id = window.Telegram.WebApp.initDataUnsafe?.user?.id || 'dev-mode-id';
-      }
-    } catch (err) {
-      console.error('Failed to read telegramId', err);
+    const stored = localStorage.getItem('userId');
+    const id = stored || DEFAULT_ID;
+    if (!stored) {
+      localStorage.setItem('userId', id);
     }
-
-    setTelegramId(id);
+    setUserId(id);
 
     fetch('/api/user-auth', {
       method: 'POST',
@@ -22,13 +21,12 @@ function App() {
         'Content-Type': 'application/json',
         'ngrok-skip-browser-warning': 'true'
       },
+      // Backend still expects the field name 'telegramId'
       body: JSON.stringify({ telegramId: id })
     }).catch(err => console.error('user-auth failed', err));
   }, []);
 
-  console.log('Current telegramId:', telegramId);
-
-  return <Dashboard telegramId={telegramId} />;
+  return <Dashboard userId={userId} />;
 }
 
 export default App;

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -4,31 +4,31 @@ import { Button } from "../ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 
 
-export default function Dashboard({ telegramId }) {
+export default function Dashboard({ userId }) {
   const [videos, setVideos] = useState([]);
   const [payments, setPayments] = useState([]);
   const [adminUsers, setAdminUsers] = useState([]);
 
   useEffect(() => {
-    if (!telegramId) return;
-    fetch(`/api/user/videos?telegramId=${telegramId}`, {
+    if (!userId) return;
+    fetch(`/api/user/videos?telegramId=${userId}`, {
       headers: { 'ngrok-skip-browser-warning': 'true' }
     })
       .then(res => res.json())
       .then(setVideos);
-    fetch(`/api/payments?telegramId=${telegramId}`, {
+    fetch(`/api/payments?telegramId=${userId}`, {
       headers: { 'ngrok-skip-browser-warning': 'true' }
     })
       .then(res => res.json())
       .then(setPayments);
-    if (telegramId === '123456789') {
-      fetch(`/api/admin/users?telegramId=${telegramId}`, {
+    if (userId === '123456789') {
+      fetch(`/api/admin/users?telegramId=${userId}`, {
         headers: { 'ngrok-skip-browser-warning': 'true' }
       })
         .then(res => res.json())
         .then(setAdminUsers);
     }
-  }, [telegramId]);
+  }, [userId]);
 
   return (
     <div className="min-h-screen bg-light text-black font-suisse p-6 space-y-6">
@@ -40,7 +40,7 @@ export default function Dashboard({ telegramId }) {
         <TabsList className="bg-surface rounded-md p-1 shadow-neon">
           <TabsTrigger value="dashboard" className="text-black hover:text-accent">Dashboard</TabsTrigger>
           <TabsTrigger value="payments" className="text-black hover:text-accent">Payments</TabsTrigger>
-          {telegramId === '123456789' && (
+          {userId === '123456789' && (
             <TabsTrigger value="admin" className="text-black hover:text-accent">Admin</TabsTrigger>
           )}
         </TabsList>
@@ -114,7 +114,7 @@ export default function Dashboard({ telegramId }) {
             </CardContent>
           </Card>
         </TabsContent>
-        {telegramId === '123456789' && (
+        {userId === '123456789' && (
           <TabsContent value="admin">
             <Card className="bg-surface shadow-neon">
               <CardContent className="p-6 overflow-x-auto">


### PR DESCRIPTION
## Summary
- drop Telegram script tag
- derive a user ID from local storage in the frontend
- update Dashboard component to accept `userId` prop

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6864faee5e54832283028e33865ab68f